### PR TITLE
Fix Ethernet on the NanoPi Neo2

### DIFF
--- a/arch/arm/dts/sun50i-h5-nanopi-neo2.dts
+++ b/arch/arm/dts/sun50i-h5-nanopi-neo2.dts
@@ -141,7 +141,7 @@
 	phy = <&phy1>;
 	status = "okay";
 
-	phy1: ethernet-phy@1 {
-		reg = <1>;
+	phy1: ethernet-phy@7 {
+		reg = <7>;
 	};
 };


### PR DESCRIPTION
On the NanoPi Neo2, ethernet is on MDIO address 7, not 1. Copied from Linux 4.13 at https://github.com/torvalds/linux/commit/63b956875a1ab695c1768758e25694420dd53a37

When applied, this fixes ethernet within u-boot for the NanoPi Neo2

Before:
```
U-Boot 2017.05 (Jun 30 2017 - 12:03:24 +0800) Allwinner Technology

CPU:   Allwinner H5 (SUN50I)
Model: NanoPi H5
DRAM:  512 MiB
MMC:   SUNXI SD/MMC: 0, SUNXI SD/MMC: 1
*** Warning - bad CRC, using default environment

In:    serial
Out:   serial
Err:   serial
Net:   phy interface7
Could not get PHY for ethernet@1c30000: addr 1
No ethernet found.
cputype is 0x1
starting USB...
USB0:   USB EHCI 1.00
USB1:   USB OHCI 1.0
scanning bus 0 for devices... 1 USB Device(s) found
       scanning usb for storage devices... 0 Storage Device(s) found
Hit any key to stop autoboot:  0 
=> 
```

After:
```
U-Boot 2017.05-01037-g2013d88-dirty (Aug 16 2017 - 16:16:43 +0000) Allwinner Technology

CPU:   Allwinner H5 (SUN50I)
Model: NanoPi H5
DRAM:  512 MiB
MMC:   SUNXI SD/MMC: 0, SUNXI SD/MMC: 1
*** Warning - bad CRC, using default environment

In:    serial
Out:   serial
Err:   serial
Net:   phy interface7
eth0: ethernet@1c30000
cputype is 0x1
starting USB...
USB0:   USB EHCI 1.00
USB1:   USB OHCI 1.0
scanning bus 0 for devices... 1 USB Device(s) found
       scanning usb for storage devices... 0 Storage Device(s) found
Hit any key to stop autoboot:  0 
=> 
```