### PR TITLE
Add the required DT parts to enable Ethernet (dwmac-sun8i driver) on

### DIFF
--- a/arch/arm/dts/sun50i-h5-nanopi-neo2.dts
+++ b/arch/arm/dts/sun50i-h5-nanopi-neo2.dts
@@ -54,6 +54,7 @@
 	aliases {
 		serial0 = &uart0;
 		i2c5 = &r_i2c;
+        ethernet0 = &emac;
 	};
 
 	chosen {
@@ -92,4 +93,15 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&uart0_pins_a>;
 	status = "okay";
+};
+
+&emac {
+    pinctrl-names = "default";
+    pinctrl-0 = <&emac_rgmii_pins>;
+    phy-mode = "rgmii";
+    phy = <&phy1>;
+    status = "okay";
+    phy1: ethernet-phy@7 {
+		reg = <7>;
+    };
 };


### PR DESCRIPTION
Add the required DT parts to enable Ethernet (dwmac-sun8i driver) on the Nano Pi NEO2/NEO-Plus2 board. We can use nfs or nfsrootfs in Bootloader. Same as you do #2 
### Before
```
U-Boot 2017.11-04983-g859ef0e5df (Sep 22 2018 - 17:58:06 +0800) Allwinner Technology
CPU:   Allwinner H5 (SUN50I)
Model: FriendlyElec NanoPi H5
DRAM:  1 GiB
CPU Freq: 1008MHz
MMC:   SUNXI SD/MMC: 0, SUNXI SD/MMC: 1
*** Warning - bad CRC, using default environment

In:    serial
Out:   serial
Err:   serial
Net:   No ethernet found.
BOARD: nanopi-neo-plus2
starting USB...
No controllers found
Hit any key to stop autoboot:  0 
switch to partitions #0, OK
mmc0 is current device
Scanning mmc 0:1...
starting USB...
No controllers found
USB is stopped. Please issue 'usb start' first.
starting USB...
No controllers found
No ethernet found.
```

### After
```
U-Boot 2017.11-04983-g859ef0e5df-dirty (Sep 22 2018 - 18:00:58 +0800) Allwinner Technology

CPU:   Allwinner H5 (SUN50I)
Model: FriendlyElec NanoPi H5
DRAM:  1 GiB
CPU Freq: 1008MHz
MMC:   SUNXI SD/MMC: 0, SUNXI SD/MMC: 1
*** Warning - bad CRC, using default environment

In:    serial
Out:   serial
Err:   serial
Net:   phy interface7
eth0: ethernet@1c30000
BOARD: nanopi-neo-plus2
starting USB...
No controllers found
Hit any key to stop autoboot:  0 
=> setenv ipaddr 192.168.0.105
=> ping 192.168.0.101
Using ethernet@1c30000 device
host 192.168.0.101 is alive
=> setenv serverip 192.168.0.101
=> nfs 0x46000000 /home/www/arm/zImage
###########################################################T ######
         #################################################################
         #################################################################
         #################################################################
         #################################################################
         #################################################################
         #################################################################
         #################################################################
         #################################################################
         #################################################################
         #################################################################
         ##################################
done
Bytes transferred = 3834032 (3a80b0 hex)

> 
```