### PR TITLE
Fix compilation errors for NanoPi M1

### DIFF
--- a/scripts/Makefile.lib
+++ b/scripts/Makefile.lib
@@ -308,7 +308,7 @@ quiet_cmd_dtc = DTC     $@
 # Modified for U-Boot
 # Bring in any U-Boot-specific include at the end of the file
 cmd_dtc = mkdir -p $(dir ${dtc-tmp}) ; \
-	(cat $<; $(if $(u_boot_dtsi),echo '\#include "$(u_boot_dtsi)"')) > $(pre-tmp); \
+	(cat $<; $(if $(u_boot_dtsi),echo '#include "$(u_boot_dtsi)"')) > $(pre-tmp); \
 	$(CPP) $(dtc_cpp_flags) -x assembler-with-cpp -o $(dtc-tmp) $(pre-tmp) ; \
 	$(DTC) -O dtb -o $@ -b 0 \
 		-i $(dir $<) $(DTC_FLAGS) \


### PR DESCRIPTION
It occer such errors when i build u-boot for NanoPi M1:

  HOSTLD  scripts/dtc/dtc
/usr/bin/ld: scripts/dtc/dtc-parser.tab.o:(.bss+0x10): multiple definition of `yylloc'; scripts/dtc/dtc-lexer.lex.o:(.bss+0x0): first defined here
collect2: error: ld returned 1 exit status
make[2]: *** [scripts/Makefile.host:108：scripts/dtc/dtc] 错误 1
make[1]: *** [scripts/Makefile.build:425：scripts/dtc] 错误 2
make: *** [Makefile:491：scripts] 错误 2

Then i modify the `scripts/dtc/dtc-parser.tab.c` :

\- 1205 YYLTYPE yylloc
\+ 1205 //YYLTYPE yylloc

and

  DTC     arch/arm/dts/sun8i-h2-plus-orangepi-zero.dtb
Error: arch/arm/dts/.sun8i-h2-plus-orangepi-zero.dtb.pre.tmp:155.1-10 syntax error
FATAL ERROR: Unable to parse input tree
make[2]: *** [scripts/Makefile.lib:319：arch/arm/dts/sun8i-h2-plus-orangepi-zero.dtb] 错误 1
make[1]: *** [dts/Makefile:43：arch-dtbs] 错误 2
make: *** [Makefile:878：dts/dt.dtb] 错误 2

Build environment:
	OS : Ubuntu 20.10
        Host Compiler version : gcc version 10.2.0 (Ubuntu 10.2.0-13ubuntu1)
	Cross Compiler  version:
		$ arm-linux-gcc -v
		gcc 版本 4.9.3 (ctng-1.21.0-229g-FA)
	Compiler command :
		$ make nanopi_h3_defconfig ARCH=arm CROSS_COMPILE=arm-linux-
		$ make ARCH=arm CROSS_COMPILE=arm-linux-